### PR TITLE
Fix CSS import ordering

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -96,4 +97,3 @@
   }
 }
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');


### PR DESCRIPTION
## Summary
- move font import to the beginning of `index.css`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68695e9ea5f48328973dcd11913af1fd