### PR TITLE
Fix npm run dev on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ npm install
 
 ## Development
 
-Run the development server using:
+Run the development server using the cross-platform script:
 
 ```bash
 npm run dev
 ```
+
+The `npm run dev` script uses `cross-env` to set `NODE_ENV=development`
+in a way that works on both Windows and Unix-based systems.
 
 The app will start on port **5000**. Open [http://localhost:5000](http://localhost:5000) in your browser to view it.
 
@@ -38,5 +41,8 @@ Then start the built server with:
 ```bash
 npm start
 ```
+
+The production start script also uses `cross-env` so Windows users do not
+need a Unix-like shell.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "@types/ws": "^8.5.13",
         "@vitejs/plugin-react": "^4.3.2",
         "autoprefixer": "^10.4.20",
+        "cross-env": "^7.0.3",
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
         "postcss": "^8.4.47",
@@ -4078,6 +4079,25 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },
@@ -97,7 +97,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "cross-env": "^7.0.3"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- add cross-env as a devDependency
- update dev and start scripts to use cross-env
- mention cross-env in README so dev/production scripts work on Windows

## Testing
- `npm run check`
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_686962cdeae48328ae775332f32c5994