### PR TITLE
Fix server listen on Windows

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -60,11 +60,14 @@ app.use((req, res, next) => {
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
   const port = 5000;
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
-    log(`serving on port ${port}`);
-  });
+  server.listen(
+    {
+      port,
+      host: "0.0.0.0",
+      ...(process.platform !== "win32" ? { reusePort: true } : {}),
+    },
+    () => {
+      log(`serving on port ${port}`);
+    },
+  );
 })();


### PR DESCRIPTION
## Summary
- ensure server.listen does not use reusePort on Windows

## Testing
- `npm run check`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_686966f206c4832893fb4db72c71e527