### PR TITLE
Update hero section layout

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -1,6 +1,8 @@
 import { Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import UTDLogo from "@/resources/UTD.png";
+import VTULogo from "@/resources/VTU.png";
 
 export default function HeroSection() {
   return (
@@ -42,49 +44,49 @@ export default function HeroSection() {
         </div>
         
         {/* About Me and Education */}
-        <div className="grid lg:grid-cols-2 gap-12">
-          {/* About Me */}
-          <Card className="shadow-lg">
-            <CardContent className="p-8">
-              <h3 className="text-2xl font-bold text-[hsl(var(--portfolio-secondary))] mb-4">
-                About Me
-              </h3>
-              <div className="text-slate-600 leading-relaxed mb-6 space-y-4 font-serif">
-                <p>Hey! I'm Dhanush 😊. I recently completed my Master's in Systems Engineering and Management from UT Dallas, with a background in Industrial Engineering and a strong curiosity for how things work and how they can work better.</p>
-                <p>I've been involved in everything from analyzing data 📊 and building dashboards to managing projects and working with teams across different functions. I enjoy simplifying complex problems and turning scattered data into something useful. I’ve worked with tools like Power BI, SQL, and SAP, but what I really enjoy is the process of collaborating with people and figuring things out together 🤝.</p>
-                <p>I'm creative, practical, and always up for a good challenge 💡. I like to bring energy into the room, share ideas, and keep the work fun without losing focus. Whether I’m designing a solution, solving a problem, or just helping the team stay on track, I believe the best work happens when people feel connected, motivated, and slightly over-caffeinated ☕.</p>
-              </div>
-            </CardContent>
-          </Card>
-          
+        <div className="grid lg:grid-cols-3 gap-12 items-center">
           {/* Education */}
-          <Card className="shadow-lg">
+          <Card className="shadow-lg lg:col-span-1 justify-self-center self-center">
             <CardContent className="p-8">
               <h3 className="text-2xl font-bold text-[hsl(var(--portfolio-secondary))] mb-6">
                 Education
               </h3>
               <div className="space-y-6">
-                <div className="border-l-4 border-[hsl(var(--portfolio-primary))] pl-6">
-                  <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
-                    Master of Science in Computer Science
-                  </h4>
-                  <p className="text-slate-600 font-medium">Stanford University</p>
-                  <p className="text-slate-500 text-sm">2018 - 2020</p>
-                  <p className="text-slate-600 mt-2 text-sm">
-                    Specialized in Machine Learning and Software Engineering
-                  </p>
+                <div className="border-l-4 border-[hsl(var(--portfolio-primary))] pl-6 flex items-start">
+                  <img src={UTDLogo} alt="UT Dallas" className="w-10 h-10 mr-3 object-contain" />
+                  <div>
+                    <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
+                      MS in Systems Engineering &amp; Management
+                    </h4>
+                    <p className="text-slate-600 font-medium">University of Texas at Dallas</p>
+                    <p className="text-slate-500 text-sm">2023 - 2025</p>
+                  </div>
                 </div>
-                
-                <div className="border-l-4 border-[hsl(var(--portfolio-accent))] pl-6">
-                  <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
-                    Bachelor of Science in Information Technology
-                  </h4>
-                  <p className="text-slate-600 font-medium">University of California, Berkeley</p>
-                  <p className="text-slate-500 text-sm">2014 - 2018</p>
-                  <p className="text-slate-600 mt-2 text-sm">
-                    Magna Cum Laude, Dean's List
-                  </p>
+
+                <div className="border-l-4 border-[hsl(var(--portfolio-accent))] pl-6 flex items-start">
+                  <img src={VTULogo} alt="VTU" className="w-10 h-10 mr-3 object-contain" />
+                  <div>
+                    <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
+                      BE in Industrial Engineering &amp; Management
+                    </h4>
+                    <p className="text-slate-600 font-medium">Visvesvaraya Technological University (VTU)</p>
+                    <p className="text-slate-500 text-sm">2017 - 2021</p>
+                  </div>
                 </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* About Me */}
+          <Card className="shadow-lg lg:col-span-2 order-2">
+            <CardContent className="p-8">
+              <h3 className="text-2xl font-bold text-[hsl(var(--portfolio-secondary))] mb-4">
+                About Me
+              </h3>
+              <div className="text-slate-600 leading-relaxed mb-6 space-y-4 font-serif text-lg font-semibold">
+                <p>Hey! I'm Dhanush 😊. I recently completed my Master's in Systems Engineering and Management from UT Dallas, with a background in Industrial Engineering and a strong curiosity for how things work and how they can work better.</p>
+                <p>I've been involved in everything from analyzing data 📊 and building dashboards to managing projects and working with teams across different functions. I enjoy simplifying complex problems and turning scattered data into something useful. I’ve worked with tools like Power BI, SQL, and SAP, but what I really enjoy is the process of collaborating with people and figuring things out together 🤝.</p>
+                <p>I'm creative, practical, and always up for a good challenge 💡. I like to bring energy into the room, share ideas, and keep the work fun without losing focus. Whether I’m designing a solution, solving a problem, or just helping the team stay on track, I believe the best work happens when people feel connected, motivated, and slightly over-caffeinated ☕.</p>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- swap "About Me" and "Education" cards
- make About section wider and emphasize text
- adjust Education content with UT Dallas and VTU details

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686aba7964a08328934ca4ef8aec6287