### PR TITLE
Adjust hero and recommendation layouts

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -45,9 +45,9 @@ export default function HeroSection() {
         </div>
         
         {/* About Me and Education */}
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
+        <div className="grid lg:grid-cols-3 gap-12 items-center">
           {/* Education */}
-          <Card className="shadow-lg lg:col-span-1 justify-self-center self-center font-montserrat">
+          <Card className="shadow-lg lg:col-span-1 justify-self-center self-center font-montserrat lg:max-w-md">
             <CardContent className="p-8">
               <h3 className="text-2xl font-bold text-[hsl(var(--portfolio-secondary))] mb-6">
                 Education
@@ -173,7 +173,7 @@ export default function HeroSection() {
           </Card>
 
           {/* About Me */}
-          <Card className="shadow-lg lg:col-span-1 order-2 font-montserrat max-w-xl mx-auto">
+          <Card className="shadow-lg lg:col-span-2 order-2 font-montserrat w-full lg:max-w-none mx-auto">
             <CardContent className="p-8 text-center">
               <h3 className="text-2xl font-bold text-[hsl(var(--portfolio-secondary))] mb-4">
                 About Me

--- a/client/src/components/recommendations-section.tsx
+++ b/client/src/components/recommendations-section.tsx
@@ -107,12 +107,12 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
             <div className="overflow-hidden px-16">
               <div 
                 className="flex transition-transform duration-700 ease-in-out"
-                style={{ 
-                  transform: `translateX(calc(50% - 160px - ${currentIndex * 336}px))`,
+                style={{
+                  transform: `translateX(calc(50% - 192px - ${currentIndex * 416}px))`,
                 }}
               >
                 {recommendations.map((rec, index) => (
-                  <div key={index} className="w-80 flex-shrink-0 mx-4">
+                  <div key={index} className="w-96 flex-shrink-0 mx-4">
                     <Card className={`shadow-lg transition-all duration-300 ${
                       index === currentIndex 
                         ? 'scale-105 shadow-xl' 
@@ -132,7 +132,7 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
                             <p className="text-slate-600 text-sm">{rec.title}</p>
                           </div>
                         </div>
-                        <p className="text-slate-600 italic mb-4 text-center">"{rec.quote}"</p>
+                        <p className="text-slate-600 italic mb-4 text-center text-sm md:text-base">"{rec.quote}"</p>
                         <div className="flex justify-center text-yellow-400">
                           {[...Array(5)].map((_, i) => (
                             <Star key={i} className="w-4 h-4 fill-current" />


### PR DESCRIPTION
## Summary
- widen About Me card and shrink Education card
- adjust recommendation carousel to show 3 larger cards
- tweak recommendation quote font size

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686aee3481c88328b04b8598ca8b3993