### PR TITLE
Adjust recommendation card layout

### DIFF
--- a/client/src/components/recommendations-section.tsx
+++ b/client/src/components/recommendations-section.tsx
@@ -108,11 +108,11 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
               <div 
                 className="flex transition-transform duration-700 ease-in-out"
                 style={{
-                  transform: `translateX(calc(50% - 192px - ${currentIndex * 416}px))`,
+                  transform: `translateX(calc(50% - 25vw - ${currentIndex} * (50vw + 2rem)))`,
                 }}
               >
                 {recommendations.map((rec, index) => (
-                  <div key={index} className="w-96 flex-shrink-0 mx-4">
+                  <div key={index} className="w-[50vw] flex-shrink-0 mx-4">
                     <Card className={`shadow-lg transition-all duration-300 ${
                       index === currentIndex 
                         ? 'scale-105 shadow-xl' 
@@ -129,10 +129,10 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
                             <h4 className="font-semibold text-[hsl(var(--portfolio-secondary))]">
                               {rec.name}
                             </h4>
-                            <p className="text-slate-600 text-sm">{rec.title}</p>
+                            <p className="text-slate-600 text-xs">{rec.title}</p>
                           </div>
                         </div>
-                        <p className="text-slate-600 italic mb-4 text-center text-sm md:text-base">"{rec.quote}"</p>
+                        <p className="text-slate-600 italic mb-4 text-center text-xs md:text-sm">"{rec.quote}"</p>
                         <div className="flex justify-center text-yellow-400">
                           {[...Array(5)].map((_, i) => (
                             <Star key={i} className="w-4 h-4 fill-current" />


### PR DESCRIPTION
## Summary
- widen recommendation cards to half the viewport
- slightly reduce typography sizes

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686aefc42aa48328b7ea0a6082a13717