### PR TITLE
Fix Windows startup error

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -60,11 +60,14 @@ app.use((req, res, next) => {
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
   const port = 5000;
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
-    log(`serving on port ${port}`);
-  });
+  server.listen(
+    {
+      port,
+      host: "0.0.0.0",
+      ...(process.platform !== "win32" ? { reusePort: true } : {}),
+    },
+    () => {
+      log(`serving on port ${port}`);
+    },
+  );
 })();


### PR DESCRIPTION
## Summary
- avoid using `reusePort` on Windows

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686d8653eaf8832891a06f4cd8a07c8a