### PR TITLE
Update leadership and awards sections

### DIFF
--- a/client/src/components/awards-section.tsx
+++ b/client/src/components/awards-section.tsx
@@ -51,7 +51,7 @@ export default function AwardsSection() {
     <section id="awards" className="py-20 bg-slate-50">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
-          Awards
+          Awards & Recognition
         </h2>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           {awards.map((award, index) => (

--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -1,4 +1,11 @@
-import { Users, GraduationCap, Rocket } from "lucide-react";
+import {
+  Users,
+  GraduationCap,
+  Rocket,
+  Briefcase,
+  Lightbulb,
+  Handshake,
+} from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
@@ -25,22 +32,50 @@ export default function LeadershipSection() {
       badges: ["Innovation", "Technology Assessment", "Change Management"],
       color: "bg-orange-500",
     },
+    {
+      icon: Briefcase,
+      title: "Project Management Lead",
+      description:
+        "Oversaw simultaneous delivery of multiple client projects valued over $5M, ensuring on-time completion and 15% cost savings.",
+      badges: ["Risk Mitigation", "Stakeholder Alignment", "Budget Control"],
+      color: "bg-purple-500",
+    },
+    {
+      icon: Lightbulb,
+      title: "Strategic Initiatives Advisor",
+      description:
+        "Guided cross-departmental teams to identify growth opportunities and launch initiatives that increased market reach by 20%.",
+      badges: ["Strategy", "Cross-Functional", "Data-Driven"],
+      color: "bg-teal-500",
+    },
+    {
+      icon: Handshake,
+      title: "Community Outreach Liaison",
+      description:
+        "Built partnerships with local organizations to host quarterly tech workshops, attracting over 300 participants annually.",
+      badges: ["Partnerships", "Event Planning", "Public Relations"],
+      color: "bg-indigo-500",
+    },
   ];
 
   return (
     <section id="leadership" className="py-20 bg-white">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
-          Leadership
+          Leadership Experience
         </h2>
         <div className="max-w-4xl mx-auto space-y-8">
           {leadership.map((item, index) => (
-            <Card key={index} className="bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300">
-              <CardContent className="p-8">
-                <div className="flex items-start space-x-6">
-                  <div className={`w-16 h-16 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
-                    <item.icon className="text-white w-8 h-8" />
-                  </div>
+            <div
+              key={index}
+              className={`md:w-1/2 ${index % 2 === 0 ? 'md:mr-auto' : 'md:ml-auto'}`}
+            >
+              <Card className="bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300">
+                <CardContent className="p-8">
+                  <div className="flex items-start space-x-6">
+                    <div className={`w-16 h-16 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
+                      <item.icon className="text-white w-8 h-8" />
+                    </div>
                   <div className="flex-1">
                     <h3 className="text-xl font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
                       {item.title}
@@ -55,8 +90,9 @@ export default function LeadershipSection() {
                     </div>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rename Leadership section heading to 'Leadership Experience'
- rename Awards section heading to 'Awards & Recognition'
- add three new leadership cards and alternate layout left and right

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686eeceeab3c83289e29aa2b5cd3b317