### PR TITLE
Add hover effects and layout improvements

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -29,7 +29,7 @@ export default function HeroSection() {
         <div className="grid lg:grid-cols-3 gap-12 items-center mb-16">
           {/* Video Embed */}
           <div className="relative lg:col-span-2">
-            <div className="aspect-video bg-slate-200 rounded-xl shadow-lg overflow-hidden">
+            <div className="aspect-video bg-slate-200 rounded-xl shadow-lg overflow-hidden transform transition-all duration-500 hover:-translate-y-1 hover:scale-105 hover:shadow-2xl hover:ring-4 hover:ring-[hsl(var(--portfolio-primary))]/50">
               <iframe
                 className="w-full h-full"
                 src="https://www.youtube.com/embed/MNKRUlD76x0"
@@ -71,16 +71,18 @@ export default function HeroSection() {
               <div className="space-y-6">
                 <HoverCard>
                   <HoverCardTrigger asChild>
-                    <div className="border-l-4 border-[hsl(var(--portfolio-primary))] pl-6 flex items-start cursor-pointer">
-                      <img src={UTDLogo} alt="UT Dallas" className="w-10 h-10 mr-3 object-contain" />
-                      <div>
-                        <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
-                          MS in Systems Engineering &amp; Management
-                        </h4>
-                        <p className="text-slate-600 font-medium">University of Texas at Dallas</p>
-                        <p className="text-slate-500 text-sm">2023 - 2025</p>
-                      </div>
-                    </div>
+                    <Card className="border-l-4 border-[hsl(var(--portfolio-primary))] shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 hover:scale-105 cursor-pointer">
+                      <CardContent className="pl-6 py-4 flex items-start">
+                        <img src={UTDLogo} alt="UT Dallas" className="w-10 h-10 mr-3 object-contain" />
+                        <div>
+                          <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
+                            MS in Systems Engineering &amp; Management
+                          </h4>
+                          <p className="text-slate-600 font-medium">University of Texas at Dallas</p>
+                          <p className="text-slate-500 text-sm">2023 - 2025</p>
+                        </div>
+                      </CardContent>
+                    </Card>
                   </HoverCardTrigger>
                   <HoverCardContent className="w-[32rem]" side="right">
                     <div className="flex items-start mb-2">
@@ -133,16 +135,18 @@ export default function HeroSection() {
 
                 <HoverCard>
                   <HoverCardTrigger asChild>
-                    <div className="border-l-4 border-[hsl(var(--portfolio-accent))] pl-6 flex items-start cursor-pointer">
-                      <img src={VTULogo} alt="VTU" className="w-10 h-10 mr-3 object-contain" />
-                      <div>
-                        <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
-                          BE in Industrial Engineering &amp; Management
-                        </h4>
-                        <p className="text-slate-600 font-medium">Visvesvaraya Technological University (VTU)</p>
-                        <p className="text-slate-500 text-sm">2017 - 2021</p>
-                      </div>
-                    </div>
+                    <Card className="border-l-4 border-[hsl(var(--portfolio-accent))] shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 hover:scale-105 cursor-pointer">
+                      <CardContent className="pl-6 py-4 flex items-start">
+                        <img src={VTULogo} alt="VTU" className="w-10 h-10 mr-3 object-contain" />
+                        <div>
+                          <h4 className="font-semibold text-lg text-[hsl(var(--portfolio-secondary))]">
+                            BE in Industrial Engineering &amp; Management
+                          </h4>
+                          <p className="text-slate-600 font-medium">Visvesvaraya Technological University (VTU)</p>
+                          <p className="text-slate-500 text-sm">2017 - 2021</p>
+                        </div>
+                      </CardContent>
+                    </Card>
                   </HoverCardTrigger>
                   <HoverCardContent className="w-[32rem]" side="right">
                     <div className="flex items-start mb-2">

--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -64,23 +64,19 @@ export default function LeadershipSection() {
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Leadership Experience
         </h2>
-        <div className="max-w-4xl mx-auto space-y-8">
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
           {leadership.map((item, index) => (
-            <div
-              key={index}
-              className={`md:w-1/2 ${index % 2 === 0 ? 'md:mr-auto' : 'md:ml-auto'}`}
-            >
-              <Card className="bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300">
-                <CardContent className="p-8">
-                  <div className="flex items-start space-x-6">
-                    <div className={`w-16 h-16 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
-                      <item.icon className="text-white w-8 h-8" />
-                    </div>
+            <Card key={index} className="bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300 h-full">
+              <CardContent className="p-6">
+                <div className="flex items-start space-x-4">
+                  <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
+                    <item.icon className="text-white w-7 h-7" />
+                  </div>
                   <div className="flex-1">
-                    <h3 className="text-xl font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
+                    <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
                       {item.title}
                     </h3>
-                    <p className="text-slate-600 mb-4">{item.description}</p>
+                    <p className="text-slate-600 mb-4 text-sm">{item.description}</p>
                     <div className="flex flex-wrap gap-2">
                       {item.badges.map((badge, badgeIndex) => (
                         <Badge key={badgeIndex} variant="secondary" className="text-xs">
@@ -90,9 +86,8 @@ export default function LeadershipSection() {
                     </div>
                   </div>
                 </div>
-                </CardContent>
-              </Card>
-            </div>
+              </CardContent>
+            </Card>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make hero video hover pop with a glow
- wrap each degree in a card with hover effects
- display leadership cards in two rows of three and shrink content

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686ef0670a0883289868fa23836b2a4a