### PR TITLE
Add framer animations and interactive leadership dialogs

### DIFF
--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { motion } from "framer-motion";
 import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -24,7 +25,12 @@ export default function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-slate-200 shadow-sm font-montserrat">
+    <motion.header
+      initial={{ y: -50, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.6 }}
+      className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-slate-200 shadow-sm font-montserrat"
+    >
       <div className="container mx-auto px-4 py-4">
         <nav className="flex justify-between items-center">
           <div className="font-semibold text-xl text-[hsl(var(--portfolio-secondary))]">
@@ -73,6 +79,6 @@ export default function Header() {
           </div>
         )}
       </div>
-    </header>
+    </motion.header>
   );
 }

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -20,15 +20,26 @@ import { Card, CardContent } from "@/components/ui/card";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import UTDLogo from "@/resources/UTD.png";
 import VTULogo from "@/resources/VTU.png";
+import { motion } from "framer-motion";
 
 export default function HeroSection() {
   return (
-    <section className="pt-10 pb-20 bg-gradient-to-br from-slate-50 to-white">
+    <motion.section
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+      className="pt-10 pb-20 bg-gradient-to-br from-slate-50 to-white"
+    >
       <div className="container mx-auto px-4">
         {/* Video and Pitch Section */}
         <div className="grid lg:grid-cols-3 gap-12 items-center mb-16">
           {/* Video Embed */}
-          <div className="relative lg:col-span-2">
+          <motion.div
+            initial={{ opacity: 0, x: -50 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+            className="relative lg:col-span-2"
+          >
             <div className="aspect-video bg-slate-200 rounded-xl shadow-lg overflow-hidden transform transition-all duration-500 hover:-translate-y-1 hover:scale-105 hover:shadow-2xl hover:ring-4 hover:ring-[hsl(var(--portfolio-primary))]/50">
               <iframe
                 className="w-full h-full"
@@ -39,12 +50,17 @@ export default function HeroSection() {
                 allowFullScreen
               ></iframe>
             </div>
-          </div>
-          
+          </motion.div>
+
           {/* Watch Pitch CTA */}
-          <div className="space-y-6 lg:col-span-1">
+          <motion.div
+            initial={{ opacity: 0, x: 50 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.6, delay: 0.4 }}
+            className="space-y-6 lg:col-span-1"
+          >
             <Card className="shadow-lg font-montserrat">
-              <CardContent className="p-8" style={{ fontFamily: "Georgia, serif" }}>
+              <CardContent className="p-8 font-montserrat">
                 <h2 className="text-2xl font-bold text-[hsl(var(--portfolio-secondary))] mb-4">
                   Who am I?
                 </h2>
@@ -57,7 +73,7 @@ export default function HeroSection() {
                 </Button>
               </CardContent>
             </Card>
-          </div>
+          </motion.div>
         </div>
         
         {/* About Me and Education */}
@@ -207,6 +223,6 @@ export default function HeroSection() {
           </Card>
         </div>
       </div>
-    </section>
+    </motion.section>
   );
 }

--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 
 export default function LeadershipSection() {
   const leadership = [
@@ -17,6 +18,7 @@ export default function LeadershipSection() {
       description: "Led a cross-functional team of 8 developers and designers to deliver a mission-critical e-commerce platform, resulting in a 40% increase in user engagement and 25% boost in conversion rates.",
       badges: ["Team Management", "Agile Methodology", "Strategic Planning"],
       color: "bg-[hsl(var(--portfolio-primary))]",
+      details: "Led an agile team of 8 through weekly sprints and coordinated design reviews to ship a full-stack e-commerce platform ahead of schedule.",
     },
     {
       icon: GraduationCap,
@@ -24,6 +26,7 @@ export default function LeadershipSection() {
       description: "Established and coordinated a company-wide mentorship program that paired senior developers with junior team members, improving retention rates by 35% and accelerating skill development.",
       badges: ["Mentoring", "Program Development", "Talent Development"],
       color: "bg-[hsl(var(--portfolio-accent))]",
+      details: "Created onboarding resources and ran monthly check-ins, pairing 20+ juniors with mentors across departments.",
     },
     {
       icon: Rocket,
@@ -31,6 +34,7 @@ export default function LeadershipSection() {
       description: "Chaired the innovation committee responsible for evaluating and implementing emerging technologies, leading to the adoption of three key technologies that improved development efficiency by 50%.",
       badges: ["Innovation", "Technology Assessment", "Change Management"],
       color: "bg-orange-500",
+      details: "Facilitated quarterly hackathons and curated a tech radar that guided adoption of cloud tooling and CI/CD pipelines.",
     },
     {
       icon: Briefcase,
@@ -39,6 +43,7 @@ export default function LeadershipSection() {
         "Oversaw simultaneous delivery of multiple client projects valued over $5M, ensuring on-time completion and 15% cost savings.",
       badges: ["Risk Mitigation", "Stakeholder Alignment", "Budget Control"],
       color: "bg-purple-500",
+      details: "Implemented risk dashboards and weekly stakeholder syncs to keep five concurrent projects on track and under budget.",
     },
     {
       icon: Lightbulb,
@@ -47,6 +52,7 @@ export default function LeadershipSection() {
         "Guided cross-departmental teams to identify growth opportunities and launch initiatives that increased market reach by 20%.",
       badges: ["Strategy", "Cross-Functional", "Data-Driven"],
       color: "bg-teal-500",
+      details: "Analyzed market trends and presented quarterly reports that shaped product expansion into two new verticals.",
     },
     {
       icon: Handshake,
@@ -55,6 +61,7 @@ export default function LeadershipSection() {
         "Built partnerships with local organizations to host quarterly tech workshops, attracting over 300 participants annually.",
       badges: ["Partnerships", "Event Planning", "Public Relations"],
       color: "bg-indigo-500",
+      details: "Negotiated sponsorships and coordinated volunteers to deliver hands-on sessions for students and professionals.",
     },
   ];
 
@@ -66,28 +73,53 @@ export default function LeadershipSection() {
         </h2>
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
           {leadership.map((item, index) => (
-            <Card key={index} className="bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300 h-full">
-              <CardContent className="p-6">
-                <div className="flex items-start space-x-4">
+            <Dialog key={index}>
+              <DialogTrigger asChild>
+                <Card className="bg-slate-50 shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
+                  <CardContent className="p-6">
+                    <div className="flex items-start space-x-4">
+                      <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
+                        <item.icon className="text-white w-7 h-7" />
+                      </div>
+                      <div className="flex-1">
+                        <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
+                          {item.title}
+                        </h3>
+                        <p className="text-slate-600 mb-4 text-sm">{item.description}</p>
+                        <div className="flex flex-wrap gap-2">
+                          {item.badges.map((badge, badgeIndex) => (
+                            <Badge key={badgeIndex} variant="secondary" className="text-xs">
+                              {badge}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </DialogTrigger>
+              <DialogContent className="w-[95vw] max-w-md p-6">
+                <div className="flex items-start space-x-4 mb-4">
                   <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
                     <item.icon className="text-white w-7 h-7" />
                   </div>
-                  <div className="flex-1">
+                  <div>
                     <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
                       {item.title}
                     </h3>
-                    <p className="text-slate-600 mb-4 text-sm">{item.description}</p>
-                    <div className="flex flex-wrap gap-2">
-                      {item.badges.map((badge, badgeIndex) => (
-                        <Badge key={badgeIndex} variant="secondary" className="text-xs">
-                          {badge}
-                        </Badge>
-                      ))}
-                    </div>
+                    <p className="text-slate-600 text-sm">{item.description}</p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+                <p className="text-slate-600 text-sm mb-4">{item.details}</p>
+                <div className="flex flex-wrap gap-2">
+                  {item.badges.map((badge, badgeIndex) => (
+                    <Badge key={badgeIndex} variant="secondary" className="text-xs">
+                      {badge}
+                    </Badge>
+                  ))}
+                </div>
+              </DialogContent>
+            </Dialog>
           ))}
         </div>
       </div>

--- a/client/src/components/projects-section.tsx
+++ b/client/src/components/projects-section.tsx
@@ -614,7 +614,7 @@ export default function ProjectsSection() {
             project.details ? (
               <Dialog key={index}>
                 <DialogTrigger asChild>
-                  <Card className="shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden transform hover:-translate-y-1 hover:scale-105 cursor-pointer">
+                  <Card className="shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 overflow-hidden cursor-pointer">
                     <img
                       src={project.image}
                       alt={project.title}
@@ -664,7 +664,7 @@ export default function ProjectsSection() {
             ) : (
               <Card
                 key={index}
-                className="shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden transform hover:-translate-y-1 hover:scale-105"
+                className="shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 overflow-hidden"
               >
                 <img
                   src={project.image}

--- a/client/src/components/recommendations-section.tsx
+++ b/client/src/components/recommendations-section.tsx
@@ -146,7 +146,7 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
                           rel="noopener noreferrer"
                         >
                           <Card
-                            className={`shadow-lg transition-all duration-300 ${
+                            className={`shadow-lg transition-all duration-300 transform hover:-translate-y-1 hover:scale-105 ${
                               index === currentIndex
                                 ? 'scale-105 shadow-xl'
                                 : 'scale-95 opacity-60'

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -102,3 +102,21 @@
 .font-montserrat {
   font-family: 'Montserrat', sans-serif;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  transition: transform 0.3s ease;
+}
+
+h1:hover,
+h2:hover,
+h3:hover,
+h4:hover,
+h5:hover,
+h6:hover {
+  transform: scale(1.05);
+}


### PR DESCRIPTION
## Summary
- animate header and hero content on page load
- match "Who am I" font with header
- smooth hover pop on headings and recommendation cards
- refine project card animations
- add hover and dialog details for leadership cards

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686ef47079e48328872d369ee7fa151e