### PR TITLE
Fix leadership cards

### DIFF
--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/hover-card";
 import SGLogo from "@/resources/SG_logo.png";
 import SGImage from "@/resources/Sg.jpg";
+import KSImage from "@/resources/KS.jpg";
 
 export default function LeadershipSection() {
   const leadership = [
@@ -29,14 +30,6 @@ export default function LeadershipSection() {
       logo: SGLogo,
       details: (
         <div className="space-y-4 text-sm text-left">
-          <p>
-            Elected by the student body, I served as an At-Large Senator within
-            UTD’s Student Government, representing the broader graduate and
-            international student community in university-wide decision-making.
-            In this role, I actively contributed to discussions on campus-wide
-            policies, budget allocations, and strategic initiatives aimed at
-            improving the student experience.
-          </p>
           <p>
             One of my most meaningful contributions was organizing the
             “Understanding Health Insurance for International Students” event,
@@ -70,11 +63,75 @@ export default function LeadershipSection() {
     },
     {
       icon: GraduationCap,
-      title: "Mentorship Program Coordinator",
-      description: "Established and coordinated a company-wide mentorship program that paired senior developers with junior team members, improving retention rates by 35% and accelerating skill development.",
-      badges: ["Mentoring", "Program Development", "Talent Development"],
+      title: "President, Cultural Club at UT Dallas",
+      description:
+        "Led the Cultural Club representing over 200 international students and organized community outreach and cultural events.",
+      badges: ["Leadership", "Community Building", "Event Planning"],
       color: "bg-[hsl(var(--portfolio-accent))]",
-      details: "Created onboarding resources and ran monthly check-ins, pairing 20+ juniors with mentors across departments.",
+      logo: KSImage,
+      details: (
+        <div className="space-y-4 text-sm text-left">
+          <p>
+            I was elected President of the Cultural Club in recognition of my
+            contributions to community engagement and outreach. The club
+            represented over 200 students from my home country and served as a
+            cultural and support hub for international students on campus. As
+            President, I led a wide range of impactful initiatives, both
+            operational and community-focused:
+          </p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>
+              Led a diverse team of undergraduate and graduate student
+              volunteers in organizing cultural, nonprofit, and social events,
+              fostering teamwork and accountability across multiple committees.
+            </li>
+            <li>
+              Acted as a key liaison between international students and local
+              communities, helping students integrate, access resources, and
+              find a sense of belonging in a multicultural campus environment.
+            </li>
+            <li>
+              Planned and executed community-driven nonprofit initiatives,
+              including a campus-wide blood donation drive and fundraising
+              campaigns for charitable organizations beyond UTD.
+            </li>
+            <li>
+              Organized an immigration-focused Q&A session featuring a top
+              Indian immigration attorney, where students received clarity on
+              F-1 visa rules, OPT/CPT, and long-term immigration concerns.
+            </li>
+            <li>
+              Drove digital engagement by creating social media content that
+              went viral within the South Asian student community, positively
+              boosting the visibility of both the club and UTD. Many incoming
+              students cited our content as a deciding factor in choosing UTD.
+            </li>
+            <li>
+              Provided direct guidance to dozens of prospective students
+              navigating the application and admissions process, often serving
+              as their first point of contact and ongoing mentor.
+            </li>
+            <li>
+              Led the club’s signature on-campus food initiatives, distributing
+              high-quality Indian meals for free at cultural festivals—an effort
+              that became widely recognized and eagerly anticipated by students
+              across campus.
+            </li>
+            <li>
+              Promoted cultural unity by organizing large-scale cultural events
+              and celebrations, ensuring that international students felt
+              welcomed, valued, and represented in the campus community.
+            </li>
+            <li>
+              Coordinated logistics for a major community event in Richmond,
+              VA, hosting over 10,000 attendees over three days. I led a team of
+              volunteers from UTD to manage event flow, guest coordination, and
+              operational support.
+            </li>
+          </ul>
+          <img src={KSImage} alt="Cultural Club" className="w-40 mx-auto rounded-md" />
+        </div>
+      ),
     },
     {
       icon: Rocket,
@@ -121,14 +178,14 @@ export default function LeadershipSection() {
         </h2>
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
           {leadership.map((item, index) =>
-            index === 0 ? (
+            typeof item.details !== "string" ? (
               <Dialog key={index}>
                 <DialogTrigger asChild>
                   <Card className="relative bg-slate-50 shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
                     {"logo" in item && (
                       <img
                         src={(item as any).logo}
-                        alt="SG logo"
+                        alt={`${item.title} image`}
                         className="absolute left-0 top-0 h-full w-1/2 object-contain pointer-events-none opacity-90"
                         style={{
                           WebkitMaskImage:
@@ -139,7 +196,7 @@ export default function LeadershipSection() {
                       />
                     )}
                     <CardContent className="relative p-6">
-                      <div className="flex items-start space-x-4 bg-white/80 rounded p-2">
+                      <div className="inline-flex items-start space-x-4 bg-white/80 rounded p-2 w-fit">
                         <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
                           <item.icon className="text-white w-7 h-7" />
                         </div>
@@ -147,7 +204,7 @@ export default function LeadershipSection() {
                           <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
                             {item.title}
                           </h3>
-                          <p className="text-slate-600 mb-4 text-sm">{item.description}</p>
+                          <p className="text-slate-600 mb-2 text-sm">{item.description}</p>
                         </div>
                       </div>
                       <div className="absolute right-4 bottom-4 flex flex-wrap gap-2">
@@ -161,7 +218,7 @@ export default function LeadershipSection() {
                   </Card>
                 </DialogTrigger>
                 <DialogContent className="w-[95vw] max-w-4xl h-[95vh] overflow-y-auto p-6">
-                  <div className="flex items-start space-x-4 mb-4">
+                  <div className="flex items-start space-x-4 mb-2">
                     <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
                       <item.icon className="text-white w-7 h-7" />
                     </div>
@@ -169,7 +226,6 @@ export default function LeadershipSection() {
                       <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
                         {item.title}
                       </h3>
-                      <p className="text-slate-600 text-sm">{item.description}</p>
                     </div>
                   </div>
                   {item.details}
@@ -195,7 +251,7 @@ export default function LeadershipSection() {
                           <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
                             {item.title}
                           </h3>
-                          <p className="text-slate-600 mb-4 text-sm">{item.description}</p>
+                          <p className="text-slate-600 mb-2 text-sm">{item.description}</p>
                           <div className="flex flex-wrap gap-2">
                             {item.badges.map((badge, badgeIndex) => (
                               <Badge key={badgeIndex} variant="secondary" className="text-xs">
@@ -209,7 +265,7 @@ export default function LeadershipSection() {
                   </Card>
                 </DialogTrigger>
                 <DialogContent className="w-[95vw] max-w-md p-6">
-                  <div className="flex items-start space-x-4 mb-4">
+                  <div className="flex items-start space-x-4 mb-2">
                     <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>
                       <item.icon className="text-white w-7 h-7" />
                     </div>
@@ -220,7 +276,7 @@ export default function LeadershipSection() {
                       <p className="text-slate-600 text-sm">{item.description}</p>
                     </div>
                   </div>
-                  <p className="text-slate-600 text-sm mb-4">{item.details}</p>
+                  <p className="text-slate-600 text-sm mb-2">{item.details}</p>
                   <div className="flex flex-wrap gap-2">
                     {item.badges.map((badge, badgeIndex) => (
                       <Badge key={badgeIndex} variant="secondary" className="text-xs">


### PR DESCRIPTION
## Summary
- adjust layout for leadership card shadow boxes
- remove duplicate intro in At-Large dialog and tighten spacing
- add new Cultural Club leadership card with image and bullet details
- generalize large card logic

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68702e3302a4832893fd3a853931ec2a