### PR TITLE
Update certifications and remove awards section

### DIFF
--- a/client/src/components/certifications-section.tsx
+++ b/client/src/components/certifications-section.tsx
@@ -1,49 +1,47 @@
-import { Cloud, Shield, Database, Brain, Layers, BookOpen } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import CSMImage from "@/resources/csm.jpg";
+import PowerBIImage from "@/resources/powerbi.jpg";
+import GooglePMImage from "@/resources/googlepm.jpg";
+import MarketingImage from "@/resources/marketingc.jpg";
+import CBREPMImage from "@/resources/cbrepm.jpg";
+import ExternshipImage from "@/resources/externc.jpg";
 
 export default function CertificationsSection() {
   const certifications = [
     {
-      icon: Cloud,
-      title: "AWS Solutions Architect",
-      organization: "Amazon Web Services",
-      validUntil: "Dec 2024",
-      color: "bg-blue-500",
-    },
-    {
-      icon: Cloud,
-      title: "Google Cloud Professional",
-      organization: "Google Cloud Platform",
-      validUntil: "Aug 2024",
-      color: "bg-orange-500",
-    },
-    {
-      icon: Shield,
-      title: "Certified Ethical Hacker",
-      organization: "EC-Council",
-      validUntil: "Mar 2025",
-      color: "bg-green-500",
-    },
-    {
-      icon: Layers,
-      title: "Scrum Master Certified",
+      title: "Certified Scrum Master",
       organization: "Scrum Alliance",
-      validUntil: "Jun 2024",
-      color: "bg-purple-500",
+      image: CSMImage,
     },
     {
-      icon: Database,
-      title: "MongoDB Developer",
-      organization: "MongoDB University",
-      validUntil: "Nov 2024",
-      color: "bg-red-500",
+      title: "Power BI Data Analyst",
+      organization: "Microsoft",
+      image: PowerBIImage,
     },
     {
-      icon: Brain,
-      title: "Machine Learning Engineer",
-      organization: "Coursera & DeepLearning.AI",
-      validUntil: "Sep 2024",
-      color: "bg-teal-500",
+      title: "Project Management Professional (v2)",
+      organization: "Google",
+      image: GooglePMImage,
+    },
+    {
+      title: "Marketing Automation",
+      organization: "How to Build a Successful Campaign",
+      image: MarketingImage,
+    },
+    {
+      title: "Project Management Job Simulation",
+      organization: "Forage (CBRE)",
+      image: CBREPMImage,
+    },
+    {
+      title: "Market Research Externship",
+      organization: "National Research Group (NRG)",
+      image: ExternshipImage,
+    },
+    {
+      title: "Supply Chain Modelling & Analytics",
+      organization: "NPTEL",
     },
   ];
 
@@ -53,21 +51,40 @@ export default function CertificationsSection() {
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Certifications
         </h2>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {certifications.map((cert, index) => (
-            <Card key={index} className="bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300">
-              <CardContent className="p-8 text-center">
-                <div className={`w-20 h-20 ${cert.color} rounded-full flex items-center justify-center mx-auto mb-6`}>
-                  <cert.icon className="text-white w-10 h-10" />
-                </div>
-                <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
-                  {cert.title}
-                </h3>
-                <p className="text-slate-600 text-sm mb-4">{cert.organization}</p>
-                <p className="text-xs text-slate-500">Valid until: {cert.validUntil}</p>
-              </CardContent>
-            </Card>
-          ))}
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+          {certifications.map((cert) =>
+            cert.image ? (
+              <Dialog key={cert.title}>
+                <DialogTrigger asChild>
+                  <Card className="relative bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300 cursor-pointer overflow-hidden">
+                    <img
+                      src={cert.image}
+                      alt={cert.title}
+                      className="absolute inset-0 w-full h-full object-cover opacity-50"
+                    />
+                    <CardContent className="relative p-8 text-center flex flex-col items-center justify-center h-full">
+                      <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
+                        {cert.title}
+                      </h3>
+                      <p className="text-slate-600 text-sm">{cert.organization}</p>
+                    </CardContent>
+                  </Card>
+                </DialogTrigger>
+                <DialogContent className="w-[95vw] max-w-md p-0">
+                  <img src={cert.image} alt={cert.title} className="w-full h-auto object-contain" />
+                </DialogContent>
+              </Dialog>
+            ) : (
+              <Card key={cert.title} className="bg-slate-50 shadow-lg hover:shadow-xl transition-shadow duration-300 flex items-center justify-center">
+                <CardContent className="p-8 text-center">
+                  <h3 className="text-lg font-semibold text-[hsl(var(--portfolio-secondary))] mb-2">
+                    {cert.title}
+                  </h3>
+                  <p className="text-slate-600 text-sm">{cert.organization}</p>
+                </CardContent>
+              </Card>
+            )
+          )}
         </div>
       </div>
     </section>

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -10,7 +10,6 @@ export default function Header() {
     { href: "#recommendations", label: "Recommendations" },
     { href: "#projects", label: "Projects" },
     { href: "#leadership", label: "Leadership" },
-    { href: "#awards", label: "Awards" },
     { href: "#certifications", label: "Certifications" },
     { href: "#skills", label: "Skills" },
     { href: "#experience", label: "Experience" },

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -2,7 +2,6 @@ import Header from "@/components/header";
 import HeroSection from "@/components/hero-section";
 import RecommendationsSection from "@/components/recommendations-section";
 import LeadershipSection from "@/components/leadership-section";
-import AwardsSection from "@/components/awards-section";
 import CertificationsSection from "@/components/certifications-section";
 import ProjectsSection from "@/components/projects-section";
 import SkillsSection from "@/components/skills-section";
@@ -17,7 +16,6 @@ export default function Home() {
       <RecommendationsSection />
       <ProjectsSection />
       <LeadershipSection />
-      <AwardsSection />
       <CertificationsSection />
       <SkillsSection />
       <ExperienceSection />


### PR DESCRIPTION
## Summary
- remove Awards section from navigation and homepage
- redesign Certifications section using new images and popup dialogs

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68704af8c7808328a2ecc53cd0384da9