### PR TITLE
Fix leadership and skills images

### DIFF
--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -29,7 +29,8 @@ export default function LeadershipSection() {
         "Elected by the student body, I served as an At-Large Senator within UTD’s Student Government, representing the broader graduate and international student community in university-wide decision-making...",
       badges: ["Advocacy", "Event Management", "Public Speaking"],
       color: "bg-[hsl(var(--portfolio-primary))]",
-      logo: SGLogo,
+  // Use the full SG image for the card thumbnail
+  logo: SGImage,
       details: (
         <div className="space-y-4 text-sm text-left">
           <p>

--- a/client/src/components/skills-section.tsx
+++ b/client/src/components/skills-section.tsx
@@ -3,8 +3,8 @@ import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import PBIIcon from "@/resources/skills/pbi.svg";
 import ExcelIcon from "@/resources/skills/excel.svg";
 import JiraIcon from "@/resources/skills/jira.svg";
-import ServiceNowIcon from "@/resources/skills/servicenow.svg";
-import WrikeIcon from "@/resources/skills/wrike.svg";
+import ServiceNowIcon from "@/resources/servicenow.png";
+import WrikeIcon from "@/resources/wrike.png";
 import SQLIcon from "@/resources/skills/sql.svg";
 import TableauIcon from "@/resources/skills/tableau.svg";
 import HTML5Icon from "@/resources/skills/html5.svg";
@@ -12,7 +12,7 @@ import SAPIcon from "@/resources/skills/sap.svg";
 import AsanaIcon from "@/resources/skills/asana.svg";
 import GoogleAnalIcon from "@/resources/skills/googleanal.svg";
 import FigmaIcon from "@/resources/skills/figma.svg";
-import Wrike2Icon from "@/resources/skills/wrike2.svg";
+import Wrike2Icon from "@/resources/wrike.png";
 import PProIcon from "@/resources/skills/ppro.svg";
 import PShopIcon from "@/resources/skills/pshop.svg";
 import AEffectsIcon from "@/resources/skills/aeffects.svg";
@@ -60,7 +60,7 @@ export default function SkillsSection() {
           Skills & Certifications
         </h2>
         <div className="grid md:grid-cols-2 gap-8 items-start">
-          <div className="flex flex-wrap justify-center max-w-md mx-auto">
+          <div className="flex flex-wrap justify-center max-w-md mx-auto border rounded-lg p-4">
             {skillIcons.map((icon, idx) => (
               <div
                 key={idx}
@@ -70,14 +70,14 @@ export default function SkillsSection() {
               </div>
             ))}
           </div>
-          <div className="grid gap-4">
+          <div className="grid gap-4 max-w-md mx-auto border rounded-lg p-4">
             {certifications.map((cert) =>
               cert.image ? (
                 <Dialog key={cert.title}>
                   <DialogTrigger asChild>
                     <Card className="bg-slate-50 shadow flex items-center cursor-pointer hover:shadow-xl transition-shadow">
-                      <CardContent className="p-4 flex items-center space-x-4">
-                        <img src={cert.image} alt={cert.title} className="w-12 h-12 object-contain" />
+                      <CardContent className="p-2 flex items-center space-x-2">
+                        <img src={cert.image} alt={cert.title} className="w-10 h-10 object-contain" />
                         <div>
                           <h3 className="text-sm font-semibold text-[hsl(var(--portfolio-secondary))]">
                             {cert.title}
@@ -93,7 +93,7 @@ export default function SkillsSection() {
                 </Dialog>
               ) : (
                 <Card key={cert.title} className="bg-slate-50 shadow flex items-center">
-                  <CardContent className="p-4">
+                  <CardContent className="p-2">
                     <h3 className="text-sm font-semibold text-[hsl(var(--portfolio-secondary))]">
                       {cert.title}
                     </h3>


### PR DESCRIPTION
## Summary
- use `Sg.jpg` as the thumbnail for the Student Government leadership card
- load valid PNG logos for ServiceNow and Wrike icons
- wrap skills and certifications in bordered boxes and make certification cards smaller

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68707d6a1e908328a93b5061157f05f2