### PR TITLE
Revamp color palette

### DIFF
--- a/client/src/components/about-section.tsx
+++ b/client/src/components/about-section.tsx
@@ -24,7 +24,7 @@ export default function AboutSection() {
   ];
 
   return (
-    <section id="about" className="py-20 bg-white font-montserrat">
+    <section id="about" className="py-20 bg-[hsl(var(--portfolio-slate-50))] font-montserrat">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
@@ -32,7 +32,7 @@ export default function AboutSection() {
           </h2>
           <div className="grid lg:grid-cols-3 gap-8">
             {features.map((feature, index) => (
-              <Card key={index} className="bg-slate-50 hover:shadow-lg transition-shadow duration-300">
+              <Card key={index} className="bg-[hsl(var(--portfolio-slate-50))] hover:shadow-lg transition-shadow duration-300">
                 <CardContent className="p-8">
                   <div className={`w-16 h-16 ${feature.color} rounded-full flex items-center justify-center mb-6`}>
                     <feature.icon className="text-white w-8 h-8" />

--- a/client/src/components/awards-section.tsx
+++ b/client/src/components/awards-section.tsx
@@ -48,7 +48,7 @@ export default function AwardsSection() {
   ];
 
   return (
-    <section id="awards" className="py-20 bg-slate-50">
+    <section id="awards" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Awards & Recognition

--- a/client/src/components/experience-section.tsx
+++ b/client/src/components/experience-section.tsx
@@ -46,7 +46,7 @@ export default function ExperienceSection() {
   ];
 
   return (
-    <section id="experience" className="py-20 bg-slate-50">
+    <section id="experience" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Experience

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -28,7 +28,7 @@ export default function HeroSection() {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.6 }}
-      className="pt-10 pb-20 bg-gradient-to-br from-slate-50 to-white"
+      className="pt-10 pb-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.1)] to-white"
     >
       <div className="container mx-auto px-4">
         {/* Video and Pitch Section */}

--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -277,7 +277,7 @@ export default function LeadershipSection() {
   ];
 
   return (
-    <section id="leadership" className="py-20 bg-white">
+    <section id="leadership" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Leadership Experience
@@ -287,7 +287,7 @@ export default function LeadershipSection() {
             typeof item.details !== "string" ? (
               <Dialog key={index}>
                 <DialogTrigger asChild>
-                  <Card className="relative bg-slate-50 shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
+                  <Card className="relative bg-[hsl(var(--portfolio-slate-50))] shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
                     {"logo" in item && (
                     <img
                       src={(item as any).logo}
@@ -347,7 +347,7 @@ export default function LeadershipSection() {
             ) : (
               <Dialog key={index}>
                 <DialogTrigger asChild>
-                  <Card className="bg-slate-50 shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
+                  <Card className="bg-[hsl(var(--portfolio-slate-50))] shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
                     <CardContent className="p-6">
                       <div className="flex items-start space-x-4">
                         <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>

--- a/client/src/components/projects-section.tsx
+++ b/client/src/components/projects-section.tsx
@@ -604,7 +604,7 @@ export default function ProjectsSection() {
   ];
 
   return (
-    <section id="projects" className="py-20 bg-slate-50">
+    <section id="projects" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Projects

--- a/client/src/components/recommendations-section.tsx
+++ b/client/src/components/recommendations-section.tsx
@@ -101,7 +101,7 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
   }, [recommendations.length, startCarousel]);
 
   return (
-    <section id="recommendations" ref={sectionRef} className="py-16 bg-slate-50">
+    <section id="recommendations" ref={sectionRef} className="py-16 bg-[hsl(var(--portfolio-slate-50))]">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-12">
           Recommendations

--- a/client/src/components/skills-section.tsx
+++ b/client/src/components/skills-section.tsx
@@ -52,7 +52,7 @@ export default function SkillsSection() {
   ];
 
   return (
-    <section id="skills" className="py-20 bg-white">
+    <section id="skills" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-8">
           Skills & Certifications
@@ -73,7 +73,7 @@ export default function SkillsSection() {
               cert.image ? (
                 <Dialog key={cert.title}>
                   <DialogTrigger asChild>
-                    <Card className="w-full bg-slate-50 shadow flex items-center cursor-pointer hover:shadow-xl transition-shadow">
+                    <Card className="w-full bg-[hsl(var(--portfolio-slate-50))] shadow flex items-center cursor-pointer hover:shadow-xl transition-shadow">
                       <CardContent className="px-2 py-1 flex items-center space-x-4">
                         <img src={cert.image} alt={cert.title} className="w-12 h-12 object-contain" />
                         <div>
@@ -90,7 +90,7 @@ export default function SkillsSection() {
                   </DialogContent>
                 </Dialog>
               ) : (
-                <Card key={cert.title} className="w-full bg-slate-50 shadow flex items-center">
+                <Card key={cert.title} className="w-full bg-[hsl(var(--portfolio-slate-50))] shadow flex items-center">
                   <CardContent className="px-2 py-1">
                     <h3 className="text-sm font-semibold whitespace-nowrap text-[hsl(var(--portfolio-secondary))]">
                       {cert.title}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,20 +21,20 @@
   --accent-foreground: hsl(220, 9%, 46%);
   --destructive: hsl(0, 84%, 60%);
   --destructive-foreground: hsl(60, 9%, 98%);
-  --ring: hsl(221, 83%, 53%);
+  --ring: hsl(262, 84%, 58%);
   --radius: 0.5rem;
   
   /* Custom portfolio colors */
-  --portfolio-primary: hsl(221, 83%, 53%);
-  --portfolio-secondary: hsl(220, 24%, 17%);
-  --portfolio-accent: hsl(189, 94%, 43%);
-  --portfolio-slate-50: hsl(210, 40%, 98%);
-  --portfolio-slate-100: hsl(210, 40%, 96%);
-  --portfolio-slate-200: hsl(214, 32%, 91%);
-  --portfolio-slate-300: hsl(213, 27%, 84%);
-  --portfolio-slate-600: hsl(218, 11%, 65%);
-  --portfolio-slate-700: hsl(215, 25%, 27%);
-  --portfolio-slate-900: hsl(220, 39%, 11%);
+  --portfolio-primary: hsl(262, 84%, 58%);
+  --portfolio-secondary: hsl(232, 24%, 16%);
+  --portfolio-accent: hsl(340, 82%, 60%);
+  --portfolio-slate-50: hsl(240, 40%, 98%);
+  --portfolio-slate-100: hsl(240, 40%, 96%);
+  --portfolio-slate-200: hsl(240, 32%, 92%);
+  --portfolio-slate-300: hsl(240, 27%, 86%);
+  --portfolio-slate-600: hsl(240, 11%, 65%);
+  --portfolio-slate-700: hsl(240, 16%, 27%);
+  --portfolio-slate-900: hsl(240, 33%, 12%);
 }
 
 .dark {
@@ -48,15 +48,25 @@
   --card-foreground: hsl(0, 0%, 98%);
   --border: hsl(240, 4%, 16%);
   --input: hsl(240, 4%, 16%);
-  --primary: hsl(221, 83%, 53%);
+  --primary: hsl(262, 84%, 58%);
   --primary-foreground: hsl(210, 40%, 98%);
-  --secondary: hsl(240, 4%, 16%);
+  --secondary: hsl(230, 6%, 10%);
   --secondary-foreground: hsl(0, 0%, 98%);
-  --accent: hsl(240, 4%, 16%);
+  --accent: hsl(340, 82%, 60%);
   --accent-foreground: hsl(0, 0%, 98%);
   --destructive: hsl(0, 63%, 31%);
   --destructive-foreground: hsl(0, 0%, 98%);
-  --ring: hsl(221, 83%, 53%);
+  --ring: hsl(262, 84%, 58%);
+  --portfolio-primary: hsl(262, 84%, 58%);
+  --portfolio-secondary: hsl(232, 24%, 16%);
+  --portfolio-accent: hsl(340, 82%, 60%);
+  --portfolio-slate-50: hsl(240, 20%, 15%);
+  --portfolio-slate-100: hsl(240, 20%, 18%);
+  --portfolio-slate-200: hsl(240, 20%, 22%);
+  --portfolio-slate-300: hsl(240, 20%, 30%);
+  --portfolio-slate-600: hsl(240, 10%, 50%);
+  --portfolio-slate-700: hsl(240, 16%, 70%);
+  --portfolio-slate-900: hsl(240, 30%, 88%);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- update portfolio color variables to a purple/pink palette
- update dark mode with matching variables
- apply new gradient to hero section
- use the new slate variable for section backgrounds

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_687090d0ab808328accfa80798bbb9b8