### PR TITLE
Improve site colors

### DIFF
--- a/client/src/components/about-section.tsx
+++ b/client/src/components/about-section.tsx
@@ -25,7 +25,10 @@ export default function AboutSection() {
   ];
 
   return (
-    <AnimatedSection id="about" className="py-20 bg-[hsl(var(--portfolio-slate-50))] font-montserrat">
+    <AnimatedSection
+      id="about"
+      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-accent)/0.05)] to-white font-montserrat"
+    >
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
@@ -33,7 +36,10 @@ export default function AboutSection() {
           </h2>
           <div className="grid lg:grid-cols-3 gap-8">
             {features.map((feature, index) => (
-              <Card key={index} className="bg-[hsl(var(--portfolio-slate-50))] hover:shadow-lg transition-shadow duration-300">
+              <Card
+                key={index}
+                className="bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] hover:shadow-lg transition-shadow duration-300"
+              >
                 <CardContent className="p-8">
                   <div className={`w-16 h-16 ${feature.color} rounded-full flex items-center justify-center mb-6`}>
                     <feature.icon className="text-white w-8 h-8" />

--- a/client/src/components/awards-section.tsx
+++ b/client/src/components/awards-section.tsx
@@ -49,7 +49,10 @@ export default function AwardsSection() {
   ];
 
   return (
-    <AnimatedSection id="awards" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
+    <AnimatedSection
+      id="awards"
+      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.05)] to-white"
+    >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Awards & Recognition

--- a/client/src/components/experience-section.tsx
+++ b/client/src/components/experience-section.tsx
@@ -47,7 +47,10 @@ export default function ExperienceSection() {
   ];
 
   return (
-    <AnimatedSection id="experience" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
+    <AnimatedSection
+      id="experience"
+      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-accent)/0.05)] to-white"
+    >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Experience

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -3,7 +3,9 @@ import { Button } from "@/components/ui/button";
 
 export default function Footer() {
   return (
-    <footer className="py-12 bg-[hsl(var(--portfolio-secondary))] text-white">
+    <footer
+      className="py-12 bg-gradient-to-br from-[hsl(var(--portfolio-secondary))] via-[hsl(var(--portfolio-primary)/0.3)] to-[hsl(var(--portfolio-secondary))] text-white"
+    >
       <div className="container mx-auto px-4">
         <div className="text-center">
           <h3 className="text-2xl font-bold mb-4">Let's Work Together</h3>

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -27,7 +27,7 @@ export default function Header() {
       initial={{ y: -50, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
-      className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-slate-200 shadow-sm font-montserrat"
+      className="sticky top-0 z-50 bg-gradient-to-r from-white via-[hsl(var(--portfolio-slate-50))] to-white/90 backdrop-blur-sm border-b border-slate-200 shadow-sm font-montserrat"
     >
       <div className="container mx-auto px-4 py-4">
         <nav className="flex justify-between items-center">

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -28,7 +28,7 @@ export default function HeroSection() {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.6 }}
-      className="pt-10 pb-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.1)] to-white"
+      className="pt-10 pb-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-accent)/0.1)] to-white"
     >
       <div className="container mx-auto px-4">
         {/* Video and Pitch Section */}

--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -285,7 +285,10 @@ export default function LeadershipSection() {
   ];
 
   return (
-    <AnimatedSection id="leadership" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
+    <AnimatedSection
+      id="leadership"
+      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-accent)/0.05)] to-white"
+    >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Leadership Experience
@@ -295,7 +298,9 @@ export default function LeadershipSection() {
             typeof item.details !== "string" ? (
               <Dialog key={index}>
                 <DialogTrigger asChild>
-                  <Card className="relative bg-[hsl(var(--portfolio-slate-50))] shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
+                  <Card
+                    className="relative bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer"
+                  >
                     {"logo" in item && (
                     <img
                       src={(item as any).logo}
@@ -355,7 +360,7 @@ export default function LeadershipSection() {
             ) : (
               <Dialog key={index}>
                 <DialogTrigger asChild>
-                  <Card className="bg-[hsl(var(--portfolio-slate-50))] shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
+                  <Card className="bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 h-full cursor-pointer">
                     <CardContent className="p-6">
                       <div className="flex items-start space-x-4">
                         <div className={`w-14 h-14 ${item.color} rounded-full flex items-center justify-center flex-shrink-0`}>

--- a/client/src/components/projects-section.tsx
+++ b/client/src/components/projects-section.tsx
@@ -605,7 +605,10 @@ export default function ProjectsSection() {
   ];
 
   return (
-    <AnimatedSection id="projects" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
+    <AnimatedSection
+      id="projects"
+      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.05)] to-white"
+    >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
           Projects

--- a/client/src/components/recommendations-section.tsx
+++ b/client/src/components/recommendations-section.tsx
@@ -102,7 +102,11 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
   }, [recommendations.length, startCarousel]);
 
   return (
-    <AnimatedSection id="recommendations" ref={sectionRef as any} className="py-16 bg-[hsl(var(--portfolio-slate-50))]">
+    <AnimatedSection
+      id="recommendations"
+      ref={sectionRef as any}
+      className="py-16 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.05)] to-white"
+    >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-12">
           Recommendations

--- a/client/src/components/skills-section.tsx
+++ b/client/src/components/skills-section.tsx
@@ -53,7 +53,10 @@ export default function SkillsSection() {
   ];
 
   return (
-    <AnimatedSection id="skills" className="py-20 bg-[hsl(var(--portfolio-slate-50))]">
+    <AnimatedSection
+      id="skills"
+      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.05)] to-white"
+    >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-8">
           Skills & Certifications
@@ -74,7 +77,9 @@ export default function SkillsSection() {
               cert.image ? (
                 <Dialog key={cert.title}>
                   <DialogTrigger asChild>
-                    <Card className="w-full md:w-80 bg-[hsl(var(--portfolio-slate-50))] shadow flex items-center cursor-pointer hover:shadow-xl transition-shadow">
+                    <Card
+                      className="w-full md:w-80 bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow flex items-center cursor-pointer hover:shadow-xl transition-shadow"
+                    >
                       <CardContent className="px-2 py-1 flex items-center space-x-4">
                         <img src={cert.image} alt={cert.title} className="w-12 h-12 object-contain" />
                         <div>
@@ -91,7 +96,10 @@ export default function SkillsSection() {
                   </DialogContent>
                 </Dialog>
               ) : (
-                <Card key={cert.title} className="w-full md:w-80 bg-[hsl(var(--portfolio-slate-50))] shadow flex items-center">
+                <Card
+                  key={cert.title}
+                  className="w-full md:w-80 bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow flex items-center"
+                >
                   <CardContent className="px-2 py-1">
                     <h3 className="text-sm font-semibold whitespace-nowrap text-[hsl(var(--portfolio-secondary))]">
                       {cert.title}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  --background: hsl(0, 0%, 100%);
+  --background: hsl(210, 40%, 98%);
   --foreground: hsl(20, 14.3%, 4.1%);
   --muted: hsl(220, 13%, 96%);
   --muted-foreground: hsl(25, 5.3%, 44.7%);
@@ -13,7 +13,7 @@
   --card-foreground: hsl(20, 14.3%, 4.1%);
   --border: hsl(220, 13%, 91%);
   --input: hsl(220, 13%, 91%);
-  --primary: hsl(221, 83%, 53%);
+  --primary: hsl(204, 85%, 45%);
   --primary-foreground: hsl(210, 40%, 98%);
   --secondary: hsl(220, 14%, 96%);
   --secondary-foreground: hsl(220, 9%, 46%);
@@ -21,24 +21,24 @@
   --accent-foreground: hsl(220, 9%, 46%);
   --destructive: hsl(0, 84%, 60%);
   --destructive-foreground: hsl(60, 9%, 98%);
-  --ring: hsl(262, 84%, 58%);
+  --ring: hsl(204, 85%, 45%);
   --radius: 0.5rem;
   
   /* Custom portfolio colors */
-  --portfolio-primary: hsl(262, 84%, 58%);
-  --portfolio-secondary: hsl(232, 24%, 16%);
-  --portfolio-accent: hsl(340, 82%, 60%);
-  --portfolio-slate-50: hsl(240, 40%, 98%);
-  --portfolio-slate-100: hsl(240, 40%, 96%);
-  --portfolio-slate-200: hsl(240, 32%, 92%);
-  --portfolio-slate-300: hsl(240, 27%, 86%);
-  --portfolio-slate-600: hsl(240, 11%, 65%);
-  --portfolio-slate-700: hsl(240, 16%, 27%);
-  --portfolio-slate-900: hsl(240, 33%, 12%);
+  --portfolio-primary: hsl(204, 85%, 45%);
+  --portfolio-secondary: hsl(230, 35%, 18%);
+  --portfolio-accent: hsl(339, 84%, 62%);
+  --portfolio-slate-50: hsl(210, 40%, 98%);
+  --portfolio-slate-100: hsl(210, 40%, 96%);
+  --portfolio-slate-200: hsl(210, 32%, 92%);
+  --portfolio-slate-300: hsl(210, 24%, 87%);
+  --portfolio-slate-600: hsl(210, 16%, 47%);
+  --portfolio-slate-700: hsl(210, 18%, 31%);
+  --portfolio-slate-900: hsl(210, 36%, 13%);
 }
 
 .dark {
-  --background: hsl(240, 10%, 4%);
+  --background: hsl(230, 15%, 12%);
   --foreground: hsl(0, 0%, 98%);
   --muted: hsl(240, 4%, 16%);
   --muted-foreground: hsl(240, 5%, 65%);
@@ -56,17 +56,17 @@
   --accent-foreground: hsl(0, 0%, 98%);
   --destructive: hsl(0, 63%, 31%);
   --destructive-foreground: hsl(0, 0%, 98%);
-  --ring: hsl(262, 84%, 58%);
-  --portfolio-primary: hsl(262, 84%, 58%);
-  --portfolio-secondary: hsl(232, 24%, 16%);
-  --portfolio-accent: hsl(340, 82%, 60%);
-  --portfolio-slate-50: hsl(240, 20%, 15%);
-  --portfolio-slate-100: hsl(240, 20%, 18%);
-  --portfolio-slate-200: hsl(240, 20%, 22%);
-  --portfolio-slate-300: hsl(240, 20%, 30%);
-  --portfolio-slate-600: hsl(240, 10%, 50%);
-  --portfolio-slate-700: hsl(240, 16%, 70%);
-  --portfolio-slate-900: hsl(240, 30%, 88%);
+  --ring: hsl(204, 85%, 55%);
+  --portfolio-primary: hsl(204, 85%, 55%);
+  --portfolio-secondary: hsl(230, 35%, 90%);
+  --portfolio-accent: hsl(339, 84%, 72%);
+  --portfolio-slate-50: hsl(230, 25%, 15%);
+  --portfolio-slate-100: hsl(230, 25%, 20%);
+  --portfolio-slate-200: hsl(230, 25%, 25%);
+  --portfolio-slate-300: hsl(230, 25%, 32%);
+  --portfolio-slate-600: hsl(230, 30%, 56%);
+  --portfolio-slate-700: hsl(230, 35%, 75%);
+  --portfolio-slate-900: hsl(230, 50%, 88%);
 }
 
 @layer base {
@@ -75,8 +75,13 @@
   }
 
   body {
-    @apply font-sans antialiased bg-background text-foreground;
+    @apply font-sans antialiased text-foreground;
     font-family: 'Inter', sans-serif;
+    background-image: linear-gradient(
+      135deg,
+      hsl(var(--portfolio-slate-50)),
+      hsl(var(--portfolio-slate-200))
+    );
   }
   
   html {


### PR DESCRIPTION
## Summary
- brighten color palette and apply gradient background
- add colorful gradients to sections and cards
- tweak header and footer styles for vibrance

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_687178eea34c83288b3e9739380573c2