### PR TITLE
Apply pastel backgrounds to sections

### DIFF
--- a/client/src/components/experience-section.tsx
+++ b/client/src/components/experience-section.tsx
@@ -49,7 +49,7 @@ export default function ExperienceSection() {
   return (
     <AnimatedSection
       id="experience"
-      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-accent)/0.05)] to-white"
+      className="py-20 bg-[#EAF1FF]"
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 export default function Footer() {
   return (
     <footer
-      className="py-12 bg-gradient-to-br from-[hsl(var(--portfolio-secondary))] via-[hsl(var(--portfolio-primary)/0.3)] to-[hsl(var(--portfolio-secondary))] text-white"
+      className="py-12 bg-[#8E72EB] text-white"
     >
       <div className="container mx-auto px-4">
         <div className="text-center">

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -27,11 +27,11 @@ export default function Header() {
       initial={{ y: -50, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
-      className="sticky top-0 z-50 bg-gradient-to-r from-white via-[hsl(var(--portfolio-slate-50))] to-white/90 backdrop-blur-sm border-b border-slate-200 shadow-sm font-montserrat"
+      className="sticky top-0 z-50 bg-[#FEFEFE] border-b border-slate-200 shadow-sm font-montserrat"
     >
       <div className="container mx-auto px-4 py-4">
         <nav className="flex justify-between items-center">
-          <div className="font-semibold text-xl text-[hsl(var(--portfolio-secondary))]">
+          <div className="font-semibold text-xl text-slate-700">
             Dhanush Gowda S
           </div>
           
@@ -40,7 +40,7 @@ export default function Header() {
               <button
                 key={link.href}
                 onClick={() => handleNavClick(link.href)}
-                className="text-slate-700 hover:text-[hsl(var(--portfolio-primary))] transition-colors duration-200 font-medium text-sm"
+                className="text-slate-700 hover:text-[#8E72EB] transition-colors duration-200 font-medium text-sm"
               >
                 {link.label}
               </button>
@@ -68,7 +68,7 @@ export default function Header() {
                 <button
                   key={link.href}
                   onClick={() => handleNavClick(link.href)}
-                  className="text-slate-700 hover:text-[hsl(var(--portfolio-primary))] transition-colors duration-200 font-medium text-left text-sm"
+                className="text-slate-700 hover:text-[#8E72EB] transition-colors duration-200 font-medium text-left text-sm"
                 >
                   {link.label}
                 </button>

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -28,7 +28,7 @@ export default function HeroSection() {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.6 }}
-      className="pt-10 pb-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-accent)/0.1)] to-white"
+      className="pt-10 pb-20 bg-[#DCFCE7]"
     >
       <div className="container mx-auto px-4">
         {/* Video and Pitch Section */}

--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -287,7 +287,7 @@ export default function LeadershipSection() {
   return (
     <AnimatedSection
       id="leadership"
-      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-accent)/0.05)] to-white"
+      className="py-20 bg-[#DBEAFE]"
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">

--- a/client/src/components/projects-section.tsx
+++ b/client/src/components/projects-section.tsx
@@ -607,7 +607,7 @@ export default function ProjectsSection() {
   return (
     <AnimatedSection
       id="projects"
-      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.05)] to-white"
+      className="py-20 bg-[#FEF5F6]"
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">

--- a/client/src/components/recommendations-section.tsx
+++ b/client/src/components/recommendations-section.tsx
@@ -105,7 +105,7 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
     <AnimatedSection
       id="recommendations"
       ref={sectionRef as any}
-      className="py-16 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.05)] to-white"
+      className="py-16 bg-[#EBF2FF]"
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-12">

--- a/client/src/components/skills-section.tsx
+++ b/client/src/components/skills-section.tsx
@@ -55,7 +55,7 @@ export default function SkillsSection() {
   return (
     <AnimatedSection
       id="skills"
-      className="py-20 bg-gradient-to-br from-[hsl(var(--portfolio-slate-50))] via-[hsl(var(--portfolio-primary)/0.05)] to-white"
+      className="py-20 bg-[#FAF5FF]"
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-8">


### PR DESCRIPTION
## Summary
- give header a solid white background
- colorize all sections with soft pastel backgrounds
- use a purple tone for the footer

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68717dbb4fcc83289e1a35a4e6b1b309