### PR TITLE
UI tweaks for multiple sections

### DIFF
--- a/client/src/components/animated-section.tsx
+++ b/client/src/components/animated-section.tsx
@@ -6,10 +6,11 @@ interface AnimatedSectionProps {
   children: ReactNode;
   className?: string;
   id?: string;
+  duration?: number;
 }
 
 const AnimatedSection = forwardRef<HTMLElement, AnimatedSectionProps>(
-  ({ children, className, id }, ref) => (
+  ({ children, className, id, duration }, ref) => (
     <motion.section
       ref={ref as any}
       id={id}
@@ -17,7 +18,7 @@ const AnimatedSection = forwardRef<HTMLElement, AnimatedSectionProps>(
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.2 }}
-      transition={{ duration: 0.6 }}
+      transition={{ duration: duration ?? 0.6 }}
     >
       {children}
     </motion.section>

--- a/client/src/components/experience-section.tsx
+++ b/client/src/components/experience-section.tsx
@@ -49,7 +49,8 @@ export default function ExperienceSection() {
   return (
     <AnimatedSection
       id="experience"
-      className="py-20"
+      className="py-10"
+      duration={1.2}
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
@@ -67,7 +68,7 @@ export default function ExperienceSection() {
                   <div className={`w-16 h-16 ${exp.color} rounded-full flex items-center justify-center flex-shrink-0 relative z-10`}>
                     <exp.icon className="text-white w-8 h-8" />
                   </div>
-                  <Card className="shadow-lg flex-1">
+                  <Card className="shadow-lg flex-1 bg-[#FEFEFE]">
                     <CardContent className="p-8">
                       <div className="flex justify-between items-start mb-4">
                         <div>

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -7,10 +7,10 @@ export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const navLinks = [
-    { href: "#recommendations", label: "Recommendations" },
     { href: "#projects", label: "Projects" },
     { href: "#leadership", label: "Leadership" },
     { href: "#skills", label: "Skills" },
+    { href: "#recommendations", label: "Recommendations" },
     { href: "#experience", label: "Experience" },
   ];
 

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -59,7 +59,7 @@ export default function HeroSection() {
             transition={{ duration: 0.6, delay: 0.4 }}
             className="space-y-6 lg:col-span-1"
           >
-            <Card className="shadow-lg font-montserrat">
+            <Card className="shadow-2xl font-montserrat">
               <CardContent className="p-8 font-montserrat">
                 <h2 className="text-2xl font-bold text-[hsl(var(--portfolio-secondary))] mb-4">
                   Who am I?

--- a/client/src/components/leadership-section.tsx
+++ b/client/src/components/leadership-section.tsx
@@ -287,7 +287,8 @@ export default function LeadershipSection() {
   return (
     <AnimatedSection
       id="leadership"
-      className="py-20"
+      className="py-10"
+      duration={1.2}
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
@@ -328,7 +329,7 @@ export default function LeadershipSection() {
                       </div>
                       <div className="absolute right-4 bottom-4 flex flex-wrap gap-2">
                         {item.badges.map((badge, badgeIndex) => (
-                          <Badge key={badgeIndex} variant="secondary" className="text-xs">
+                          <Badge key={badgeIndex} variant="outline" className="text-xs">
                             {badge}
                           </Badge>
                         ))}
@@ -350,7 +351,7 @@ export default function LeadershipSection() {
                   {item.details}
                   <div className="flex flex-wrap gap-2 mt-4">
                     {item.badges.map((badge, badgeIndex) => (
-                      <Badge key={badgeIndex} variant="secondary" className="text-xs">
+                      <Badge key={badgeIndex} variant="outline" className="text-xs">
                         {badge}
                       </Badge>
                     ))}
@@ -373,7 +374,7 @@ export default function LeadershipSection() {
                           <p className="text-slate-600 mb-2 text-sm">{item.description}</p>
                           <div className="flex flex-wrap gap-2">
                             {item.badges.map((badge, badgeIndex) => (
-                              <Badge key={badgeIndex} variant="secondary" className="text-xs">
+                              <Badge key={badgeIndex} variant="outline" className="text-xs">
                                 {badge}
                               </Badge>
                             ))}
@@ -398,7 +399,7 @@ export default function LeadershipSection() {
                   <p className="text-slate-600 text-sm mb-2">{item.details}</p>
                   <div className="flex flex-wrap gap-2">
                     {item.badges.map((badge, badgeIndex) => (
-                      <Badge key={badgeIndex} variant="secondary" className="text-xs">
+                      <Badge key={badgeIndex} variant="outline" className="text-xs">
                         {badge}
                       </Badge>
                     ))}

--- a/client/src/components/projects-section.tsx
+++ b/client/src/components/projects-section.tsx
@@ -607,7 +607,8 @@ export default function ProjectsSection() {
   return (
     <AnimatedSection
       id="projects"
-      className="py-20"
+      className="py-10"
+      duration={1.2}
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-16">
@@ -618,7 +619,7 @@ export default function ProjectsSection() {
             project.details ? (
               <Dialog key={index}>
                 <DialogTrigger asChild>
-                  <Card className="shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 overflow-hidden cursor-pointer">
+                  <Card className="shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 overflow-hidden cursor-pointer bg-[#FEFEFE]">
                     <img
                       src={project.image}
                       alt={project.title}
@@ -632,10 +633,10 @@ export default function ProjectsSection() {
                       {project.role || project.tools ? (
                         <div className="flex flex-col gap-2 mb-3">
                           {project.role && (
-                            <Badge variant="secondary" className="w-fit text-xs">Role: {project.role}</Badge>
+                            <Badge variant="outline" className="w-fit text-xs">Role: {project.role}</Badge>
                           )}
                           {project.tools && (
-                            <Badge variant="secondary" className="w-fit text-xs">Tools: {project.tools}</Badge>
+                            <Badge variant="outline" className="w-fit text-xs">Tools: {project.tools}</Badge>
                           )}
                         </div>
                       ) : (
@@ -647,7 +648,7 @@ export default function ProjectsSection() {
                           ))}
                         </div>
                       )}
-                      <Button variant="outline" size="sm">Read more</Button>
+                      <Button variant="outline" size="sm" className="text-[#6B7280]">Read more</Button>
                     </CardContent>
                   </Card>
                 </DialogTrigger>
@@ -668,7 +669,7 @@ export default function ProjectsSection() {
             ) : (
               <Card
                 key={index}
-                className="shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 overflow-hidden"
+                className="shadow-lg hover:shadow-xl transform hover:-translate-y-1 hover:scale-105 transition-all duration-300 overflow-hidden bg-[#FEFEFE]"
               >
                 <img
                   src={project.image}
@@ -683,10 +684,10 @@ export default function ProjectsSection() {
                   {project.role || project.tools ? (
                     <div className="flex flex-col gap-2 mb-3">
                       {project.role && (
-                            <Badge variant="secondary" className="w-fit text-xs">Role: {project.role}</Badge>
+                            <Badge variant="outline" className="w-fit text-xs">Role: {project.role}</Badge>
                       )}
                       {project.tools && (
-                            <Badge variant="secondary" className="w-fit text-xs">Tools: {project.tools}</Badge>
+                            <Badge variant="outline" className="w-fit text-xs">Tools: {project.tools}</Badge>
                       )}
                     </div>
                   ) : (

--- a/client/src/components/recommendations-section.tsx
+++ b/client/src/components/recommendations-section.tsx
@@ -105,7 +105,8 @@ Dhanush would be a fantastic addition to any organization, and I highly recommen
     <AnimatedSection
       id="recommendations"
       ref={sectionRef as any}
-      className="py-16"
+      className="py-10"
+      duration={1.2}
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-12">

--- a/client/src/components/skills-section.tsx
+++ b/client/src/components/skills-section.tsx
@@ -55,14 +55,15 @@ export default function SkillsSection() {
   return (
     <AnimatedSection
       id="skills"
-      className="py-20"
+      className="py-10"
+      duration={1.2}
     >
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-[hsl(var(--portfolio-secondary))] text-center mb-8">
           Skills & Certifications
         </h2>
         <div className="grid md:grid-cols-2 gap-8 items-stretch">
-          <div className="grid grid-cols-3 gap-6 place-items-center max-w-lg mx-auto border rounded-lg p-6 h-full bg-white">
+          <div className="grid grid-cols-3 gap-6 place-items-center max-w-lg mx-auto border rounded-lg p-6 h-full bg-[#FEFEFE]">
             {skillIcons.map((icon, idx) => (
               <img
                 key={idx}
@@ -72,15 +73,15 @@ export default function SkillsSection() {
               />
             ))}
           </div>
-          <div className="grid grid-flow-col grid-rows-4 gap-4 w-full border rounded-lg p-6 h-full md:auto-cols-fr">
+          <div className="grid grid-flow-col grid-rows-4 gap-4 w-full border rounded-lg p-6 h-full md:auto-cols-fr bg-[#FEFEFE]">
             {certifications.map((cert) =>
               cert.image ? (
                 <Dialog key={cert.title}>
                   <DialogTrigger asChild>
                     <Card
-                      className="w-full md:w-80 bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow flex items-center cursor-pointer hover:shadow-xl transition-shadow"
+                      className="w-full md:w-96 bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow flex items-center cursor-pointer hover:shadow-xl transition-shadow"
                     >
-                      <CardContent className="px-2 py-1 flex items-center space-x-4">
+                      <CardContent className="px-2 py-0.5 flex items-center space-x-4">
                         <img src={cert.image} alt={cert.title} className="w-12 h-12 object-contain" />
                         <div>
                           <h3 className="text-sm font-semibold whitespace-nowrap text-[hsl(var(--portfolio-secondary))]">
@@ -98,9 +99,9 @@ export default function SkillsSection() {
               ) : (
                 <Card
                   key={cert.title}
-                  className="w-full md:w-80 bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow flex items-center"
+                  className="w-full md:w-96 bg-gradient-to-br from-white to-[hsl(var(--portfolio-slate-100))] shadow flex items-center"
                 >
-                  <CardContent className="px-2 py-1">
+                  <CardContent className="px-2 py-0.5">
                     <h3 className="text-sm font-semibold whitespace-nowrap text-[hsl(var(--portfolio-secondary))]">
                       {cert.title}
                     </h3>


### PR DESCRIPTION
## Summary
- tweak hero section styling for Who Am I card
- slow down animations via new duration prop on sections
- adjust spacing for projects, leadership, skills, recommendations and experience
- style project cards and buttons
- style leadership, skills, certifications, and experience cards
- reorder navigation links in header

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6871bbd9e8ec8328bc19952487a24e8b