### PR TITLE
Update arrow image style

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -20,7 +20,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import UTDLogo from "@/resources/UTD.png";
 import VTULogo from "@/resources/VTU.png";
-import Arrow from "@/resources/Arrow.jpg";
+import Arrow from "@/resources/Arrow.png";
 import { motion } from "framer-motion";
 
 export default function HeroSection() {
@@ -64,7 +64,7 @@ export default function HeroSection() {
             <img
               src={Arrow}
               alt="Arrow pointing to the video"
-              className="hidden lg:block w-32 h-auto mx-auto -mb-4"
+              className="hidden lg:block w-32 h-auto -mb-4 lg:-ml-16"
             />
             <Card className="shadow-2xl font-montserrat">
               <CardContent className="p-8 font-montserrat">


### PR DESCRIPTION
## Summary
- use the transparent arrow image
- shift the arrow left so it sits closer to the video

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687427207bb883288951b4bb65359d9b