### PR TITLE
Move hero arrow image slightly right

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -65,7 +65,7 @@ export default function HeroSection() {
             <img
               src={Arrow}
               alt="Arrow pointing to the video"
-              className="hidden lg:block w-32 h-auto -mb-4 lg:-ml-16"
+              className="hidden lg:block w-32 h-auto -mb-4 lg:-ml-8"
             />
             <Card className="shadow-2xl font-montserrat">
               <CardContent className="p-8 font-montserrat">


### PR DESCRIPTION
## Summary
- adjust arrow margin in hero section so it's not hidden behind the video

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68742c4691508328b90ee0d4467ba636